### PR TITLE
Update AuxiliaryContact.h

### DIFF
--- a/ContactorsSimulation/header/AuxiliaryContact.h
+++ b/ContactorsSimulation/header/AuxiliaryContact.h
@@ -9,6 +9,7 @@
 
 #include "Port.h" // Include the modified Port class header file
 #include "State.h" // Include the State class header file
+#include "ErrorHandling.h" // Include the error handling module
 
 /**
  * @brief Enum representing the type of the auxiliary contact.
@@ -26,21 +27,23 @@ private:
     Port inPort; /**< In port of the auxiliary contact */
     Port outPort; /**< Out port of the auxiliary contact */
     AuxiliaryContactType type; /**< Type of the auxiliary contact (NO or NC) */
-    State state; /**< State of the contactor (coil and contacts) */
+    double maxCurrent; /**< Maximum current rating of the auxiliary contact */
+    double current; /**< Current flowing through the auxiliary contact */
 
 public:
     /**
-     * @brief Constructor with in port, out port, type, and state.
+     * @brief Constructor with in port, out port, type, and maximum current.
      * @param inPortName Name of the in port.
      * @param inPortType Type of the in port.
      * @param outPortName Name of the out port.
      * @param outPortType Type of the out port.
      * @param contactType Type of the auxiliary contact (NO or NC).
+     * @param maxCurr Maximum current rating of the auxiliary contact.
      */
     AuxiliaryContact(const std::string& inPortName, const std::string& inPortType,
                      const std::string& outPortName, const std::string& outPortType,
-                     AuxiliaryContactType contactType)
-        : inPort(inPortName, inPortType), outPort(outPortName, outPortType), type(contactType) {}
+                     AuxiliaryContactType contactType, double maxCurr)
+        : inPort(inPortName, inPortType), outPort(outPortName, outPortType), type(contactType), maxCurrent(maxCurr), current(0.0) {}
 
     /**
      * @brief Method to update the out port voltage based on the coil state.
@@ -54,6 +57,26 @@ public:
         } else {
             outPort.setVoltage(coilState ? 0.0 : inPort.getVoltage());
         }
+    }
+
+    /**
+     * @brief Method to set the current flowing through the auxiliary contact.
+     * @param curr Current value to be set.
+     * @throws MaxCurrentExceededException if the current exceeds the maximum current rating.
+     */
+    void setCurrent(double curr) {
+        if (curr > maxCurrent) {
+            throw MaxCurrentExceededException("Current exceeds maximum current for auxiliary contact.");
+        }
+        current = curr;
+    }
+
+    /**
+     * @brief Method to get the current flowing through the auxiliary contact.
+     * @return Current value.
+     */
+    double getCurrent() const {
+        return current;
     }
 
     // Other member variables and methods...


### PR DESCRIPTION
In this update:

A member double maxCurrent is added to store the maximum current rating of the auxiliary contact.
A member double current is added to store the current flowing through the auxiliary contact.
The setCurrent method is added to set the current and check if it exceeds the maximum current rating. If it does, a MaxCurrentExceededException is thrown.
The getCurrent method is added to retrieve the current value.